### PR TITLE
Disable Next.js dev indicators

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,7 @@ const nextConfig: NextConfig = {
 	output: 'export',
 	distDir: 'dist',
 	reactStrictMode: true,
+	devIndicators: false,
 	images: {
 		unoptimized: true,
 	},


### PR DESCRIPTION
Removes the floating debug circle in dev mode.